### PR TITLE
Need string.h on Windows (mingw64).

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include <ctype.h>
 #include <memory.h>
 #include <mruby.h>


### PR DESCRIPTION
Whichever header includes string.h on Linux doesn't do so on Windows, at least when compiling with mingw64.  I had to add string.h to this file.
