### PR TITLE
Stop to use variable length array

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -515,11 +515,11 @@ string_scan(mrb_state* mrb, mrb_value self) {
       if(m->num_regs == 1) {
         mrb_yield(mrb, blk, mrb_str_substr(mrb, self, m->beg[0], m->end[0] - m->beg[0]));
       } else {
-        mrb_value argv[m->num_regs - 1];
+        mrb_value argv = mrb_ary_new_capa(mrb, m->num_regs - 1);
         for(i = 1; i < m->num_regs; ++i) {
-          argv[i - 1] = mrb_str_substr(mrb, self, m->beg[i], m->end[i] - m->beg[i]);
+          mrb_ary_push(mrb, argv, mrb_str_substr(mrb, self, m->beg[i], m->end[i] - m->beg[i]));
         }
-        mrb_yield_argv(mrb, blk, m->num_regs - 1, argv);
+        mrb_yield(mrb, blk, argv);
       }
     }
 


### PR DESCRIPTION
We can use the feature because it's included in C99 but Visual Studio
C++ doesn't support it.

See also: https://msdn.microsoft.com/en-us/library/zb1574zs.aspx

If we stop to use the feature, we can build mruby-onig-regexp with
Visual Studio C++.