### PR TITLE
Use Onigumo instead of Oniguruma

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -12,8 +12,8 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
   require 'open3'
   require 'open-uri'
 
-  version = '5.9.5'
-  oniguruma_dir = "#{build_dir}/onig-#{version}"
+  version = '5.15.0'
+  oniguruma_dir = "#{build_dir}/Onigmo-Onigmo-#{version}"
   oniguruma_lib = libfile "#{oniguruma_dir}/.libs/libonig"
   header = "#{oniguruma_dir}/oniguruma.h"
 
@@ -29,7 +29,7 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
       FileUtils.mkdir_p build_dir
       Dir.chdir(build_dir) do
         File.open("onig-#{version}.tar.gz", 'wb') do |f|
-          open("http://www.geocities.jp/kosako3/oniguruma/archive/onig-#{version}.tar.gz", "accept-encoding" => "none") do |io|
+          open("https://github.com/k-takata/Onigmo/archive/Onigmo-#{version}.tar.gz", "accept-encoding" => "none") do |io|
             f.write io.read
           end
         end

--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -771,6 +771,21 @@ mrb_mruby_onig_regexp_gem_init(mrb_state* mrb) {
   mrb_define_const(mrb, clazz, "IGNORECASE", mrb_fixnum_value(ONIG_OPTION_IGNORECASE));
   mrb_define_const(mrb, clazz, "EXTENDED", mrb_fixnum_value(ONIG_OPTION_EXTEND));
   mrb_define_const(mrb, clazz, "MULTILINE", mrb_fixnum_value(ONIG_OPTION_MULTILINE));
+  mrb_define_const(mrb, clazz, "SINGLELINE", mrb_fixnum_value(ONIG_OPTION_SINGLELINE));
+  mrb_define_const(mrb, clazz, "FIND_LONGEST", mrb_fixnum_value(ONIG_OPTION_FIND_LONGEST));
+  mrb_define_const(mrb, clazz, "FIND_NOT_EMPTY", mrb_fixnum_value(ONIG_OPTION_FIND_NOT_EMPTY));
+  mrb_define_const(mrb, clazz, "NEGATE_SINGLELINE", mrb_fixnum_value(ONIG_OPTION_NEGATE_SINGLELINE));
+  mrb_define_const(mrb, clazz, "DONT_CAPTURE_GROUP", mrb_fixnum_value(ONIG_OPTION_DONT_CAPTURE_GROUP));
+  mrb_define_const(mrb, clazz, "CAPTURE_GROUP", mrb_fixnum_value(ONIG_OPTION_CAPTURE_GROUP));
+  mrb_define_const(mrb, clazz, "NOTBOL", mrb_fixnum_value(ONIG_OPTION_NOTBOL));
+  mrb_define_const(mrb, clazz, "NOTEOL", mrb_fixnum_value(ONIG_OPTION_NOTEOL));
+  mrb_define_const(mrb, clazz, "POSIX_REGION", mrb_fixnum_value(ONIG_OPTION_POSIX_REGION));
+  mrb_define_const(mrb, clazz, "ASCII_RANGE", mrb_fixnum_value(ONIG_OPTION_ASCII_RANGE));
+  mrb_define_const(mrb, clazz, "POSIX_BRACKET_ALL_RANGE", mrb_fixnum_value(ONIG_OPTION_POSIX_BRACKET_ALL_RANGE));
+  mrb_define_const(mrb, clazz, "WORD_BOUND_ALL_RANGE", mrb_fixnum_value(ONIG_OPTION_WORD_BOUND_ALL_RANGE));
+  mrb_define_const(mrb, clazz, "NEWLINE_CRLF", mrb_fixnum_value(ONIG_OPTION_NEWLINE_CRLF));
+  mrb_define_const(mrb, clazz, "NOTBOS", mrb_fixnum_value(ONIG_OPTION_NOTBOS));
+  mrb_define_const(mrb, clazz, "NOTEOS", mrb_fixnum_value(ONIG_OPTION_NOTEOS));
 
   mrb_define_method(mrb, clazz, "initialize", onig_regexp_initialize, MRB_ARGS_REQ(1) | MRB_ARGS_OPT(2));
   mrb_define_method(mrb, clazz, "==", onig_regexp_equal, MRB_ARGS_REQ(1));

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -77,8 +77,12 @@ assert("OnigRegexp#source", '15.2.15.7.8') do
   reg.source == str
 end
 
-assert('OnigRegexp#options') do
-  assert_equal OnigRegexp::MULTILINE, OnigRegexp.new(".*", OnigRegexp::MULTILINE).options
+assert('OnigRegexp#options (no options)') do
+  assert_equal OnigRegexp::ASCII_RANGE | OnigRegexp::POSIX_BRACKET_ALL_RANGE | OnigRegexp::WORD_BOUND_ALL_RANGE, OnigRegexp.new(".*").options
+end
+
+assert('OnigRegexp#options (multiline)') do
+  assert_equal OnigRegexp::MULTILINE | OnigRegexp::ASCII_RANGE | OnigRegexp::POSIX_BRACKET_ALL_RANGE | OnigRegexp::WORD_BOUND_ALL_RANGE, OnigRegexp.new(".*", OnigRegexp::MULTILINE).options
 end
 
 # Extended patterns.


### PR DESCRIPTION
I failed to install mruby-onig-regexp because oniguruma site http://www.geocities.jp/kosako3/oniguruma/ was lost.

With this patch, you can use Onigumo (鬼雲), a forked version of Oniguruma.

( CRuby merge Onigumo in 2.0 http://slide.rabbit-shocker.org/authors/znz/ruby200-regexp/ )