### PR TITLE
improve tar compatibility

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -35,7 +35,7 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
         end
 
         _pp 'extracting', "onig-#{version}"
-        `gzip -dc onig-#{version}.tar.gz | tar x`
+        `gzip -dc onig-#{version}.tar.gz | tar xf -`
         raise IOError unless $?.exitstatus
       end
     rescue IOError


### PR DESCRIPTION
Some tar implementations require `-f -` in order to read the tar image from stdin.  For example, `man tar` of NetBSD says, quote:

> ```
>      -f archive, --file archive
>                    Filename where the archive is stored.  Defaults to
>                    /dev/rst0.  If the archive is of the form:
>                    [[user@]host:]file then the archive will be processed using
>                    rmt(8).
> ```