### PR TITLE
Suppress unused variable warnings

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -288,8 +288,7 @@ onig_regexp_inspect(mrb_state *mrb, mrb_value self) {
 
 static mrb_value
 onig_regexp_to_s(mrb_state *mrb, mrb_value self) {
-  mrb_value re;
-  int options, opt;
+  int options;
   const int embeddable = ONIG_OPTION_MULTILINE|ONIG_OPTION_IGNORECASE|ONIG_OPTION_EXTEND;
   long len;
   const char* ptr;


### PR DESCRIPTION
This commit suppresses the following warnings:

    src/mruby_onig_regexp.c:292:16: warning: unused variable 'opt' [-Wunused-variable]
       int options, opt;
                    ^
    src/mruby_onig_regexp.c:291:13: warning: unused variable 're' [-Wunused-variable]
       mrb_value re;
                 ^

You can also confirm them at Travis CI:

  * https://travis-ci.org/mattn/mruby-onig-regexp/builds/82109299#L988
  * https://travis-ci.org/mattn/mruby-onig-regexp/builds/82109299#L989