### PR TITLE
Should not raise TypeError with not Regexp object

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -189,6 +189,9 @@ onig_regexp_equal(mrb_state *mrb, mrb_value self) {
   if (mrb_nil_p(other)) {
     return mrb_false_value();
   }
+  if (!mrb_obj_is_kind_of(mrb, other, mrb_class_get(mrb, "OnigRegexp"))) {
+    return mrb_false_value();
+  }
   Data_Get_Struct(mrb, self, &mrb_onig_regexp_type, self_reg);
   Data_Get_Struct(mrb, other, &mrb_onig_regexp_type, other_reg);
 

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -42,7 +42,9 @@ assert("OnigRegexp#==", '15.2.15.7.3') do
   reg3 = OnigRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+")
   reg4 = OnigRegexp.new("(https://[^/]+)[-a-zA-Z0-9./]+")
 
-  reg1 == reg2 and reg1 == reg3 and !(reg1 == reg4)
+  assert_true(reg1 == reg2 && reg1 == reg3 && !(reg1 == reg4))
+
+  assert_false(OnigRegexp.new("a") == "a")
 end
 
 assert("OnigRegexp#===", '15.2.15.7.4') do


### PR DESCRIPTION
```ruby
"a" == /a/ #=> false
/a/ == "a" #=> wrong argument type String (expected Data) (TypeError)
```

But, ISO say

```
15.2.15.7.3 Regexp#==
    a) If _other_ is not an instance of the class Regexp, return false
```