### PR TITLE
Match ruby behavior where non-match is nil not ""

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -545,7 +545,11 @@ match_data_to_a(mrb_state* mrb, mrb_value self) {
   mrb_value ret = mrb_ary_new_capa(mrb, reg->num_regs);
   int i, ai = mrb_gc_arena_save(mrb);
   for(i = 0; i < reg->num_regs; ++i) {
-    mrb_ary_push(mrb, ret, mrb_str_substr(mrb, str, reg->beg[i], reg->end[i] - reg->beg[i]));
+    if(reg->beg[i] == ONIG_REGION_NOTPOS) {
+      mrb_ary_push(mrb, ret, mrb_nil_value());
+    } else {
+      mrb_ary_push(mrb, ret, mrb_str_substr(mrb, str, reg->beg[i], reg->end[i] - reg->beg[i]));
+    }
     mrb_gc_arena_restore(mrb, ai);
   }
   return ret;

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -185,6 +185,9 @@ end
 assert('OnigMatchData#captures', '15.2.16.3.3') do
   m = onig_match_data_example
   assert_equal ['aaab', 'b'], m.captures
+
+  m = OnigRegexp.new('(\w+)(\d)?').match('+aaabb-')
+  assert_equal ['aaabb', nil], m.captures
 end
 
 assert('OnigMatchData#end', '15.2.16.3.4') do


### PR DESCRIPTION
Previously onig-regexp would return "" for a capturing group that did not match any part of the match-string.  Now onig-regexp returns nil for a capturing group that did not match any part of the match-string.