### PR TITLE
add `--enable-multithread` to Onigmo configure

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -58,7 +58,7 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
 
           _pp 'autotools', oniguruma_dir
           run_command e, './autogen.sh' if File.exists? 'autogen.sh'
-          run_command e, "./configure --disable-shared --enable-static #{host}"
+          run_command e, "./configure --disable-shared --enable-static --enable-multithread #{host}"
           run_command e, 'make'
         else
           run_command e, 'cmd /c "copy /Y win32 > NUL"'


### PR DESCRIPTION
Since mruby is designed to be from multiple threads, we need to build Onigmo in the same way.

likely to fix https://github.com/h2o/h2o/issues/902#issuecomment-218622367