### PR TITLE
link to libpthread

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -8,8 +8,8 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
 
     require 'open3'
 
-    # remove libonig
-    linker.libraries = []
+    # remove libonig, instead link directly against pthread
+    linker.libraries = ['pthread']
 
     version = '5.15.0'
     oniguruma_dir = "#{build_dir}/Onigmo-Onigmo-#{version}"


### PR DESCRIPTION
Starting from #41 libonig is built using `pthread_mutex_lock` and related functions.  And that means that we would need to link against libpthread.

I noticed this issue when trying to build H2O on OpenBSD 5.9 (that failed to build mirb and related binaries due to missing symbol: `pthread_mutex_lock`).

Note that the PR hard-codes the name of the library - we might need to spell out the correct name of the library (if any) depending on the OS (e.g. Windows).