### PR TITLE
Support none encoding option

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -61,11 +61,18 @@ static struct mrb_data_type mrb_onig_region_type = {
 
 static mrb_value
 onig_regexp_initialize(mrb_state *mrb, mrb_value self) {
-  mrb_value str, flag = mrb_nil_value();
-  mrb_get_args(mrb, "S|o", &str, &flag);
+  mrb_value str, flag = mrb_nil_value(), code = mrb_nil_value();
+  mrb_get_args(mrb, "S|oo", &str, &flag, &code);
 
   int cflag = 0;
   OnigSyntaxType* syntax = ONIG_SYNTAX_RUBY;
+  OnigEncoding enc = ONIG_ENCODING_UTF8;
+  if(mrb_string_p(code)) {
+    char const* str_code = mrb_string_value_ptr(mrb, code);
+    if(strchr(str_code, 'n') || strchr(str_code, 'N')) {
+      enc = ONIG_ENCODING_ASCII;
+    }
+  }
   if(mrb_nil_p(flag)) {
   } else if(mrb_type(flag) == MRB_TT_TRUE) {
     cflag |= ONIG_OPTION_IGNORECASE;
@@ -86,7 +93,7 @@ onig_regexp_initialize(mrb_state *mrb, mrb_value self) {
   OnigErrorInfo einfo;
   OnigRegex reg;
   int result = onig_new(&reg, (OnigUChar*)RSTRING_PTR(str), (OnigUChar*) RSTRING_PTR(str) + RSTRING_LEN(str),
-                        cflag, ONIG_ENCODING_UTF8, syntax, &einfo);
+                        cflag, enc, syntax, &einfo);
   if (result != ONIG_NORMAL) {
     char err[ONIG_MAX_ERROR_MESSAGE_LEN] = "";
     onig_error_code_to_str((OnigUChar*)err, result);
@@ -285,6 +292,9 @@ onig_regexp_inspect(mrb_state *mrb, mrb_value self) {
   char opts[4];
   if (*option_to_str(opts, onig_get_options(reg))) {
     mrb_str_cat_cstr(mrb, str, opts);
+  }
+  if (onig_get_encoding(reg) == ONIG_ENCODING_ASCII) {
+    mrb_str_cat_lit(mrb, str, "n");
   }
   return str;
 }

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -94,6 +94,7 @@ assert("OnigRegexp#inspect") do
 
   assert_equal '/(https?:\/\/[^\/]+)[-a-zA-Z0-9.\/]+/', reg.inspect
   assert_equal '/abc\nd\te/mi', OnigRegexp.new("abc\nd\te", OnigRegexp::MULTILINE | OnigRegexp::IGNORECASE).inspect
+  assert_equal '/abc/min', OnigRegexp.new("abc", OnigRegexp::MULTILINE | OnigRegexp::IGNORECASE, "none").inspect
 end
 
 assert("OnigRegexp#to_s") do
@@ -101,6 +102,7 @@ assert("OnigRegexp#to_s") do
   assert_equal '(?-mix:ab+c)', /ab+c/.to_s
   assert_equal '(?mx-i:ab+c)', OnigRegexp.new("ab+c", OnigRegexp::MULTILINE | OnigRegexp::EXTENDED).to_s
   assert_equal '(?mi-x:ab+c)', /ab+c/im.to_s
+  assert_equal '(?mi-x:ab+c)', /ab+c/imn.to_s
 end
 
 assert("OnigRegexp#to_s (composition)") do
@@ -143,6 +145,10 @@ assert("OnigRegexp#match (ignorecase)") do
     m = OnigRegexp.new(reg, OnigRegexp::IGNORECASE|OnigRegexp::EXTENDED).match(str)
     assert_equal result, m[0] if assert_false m.nil?
   end
+end
+
+assert("OnigRegexp#match (none encoding)") do
+  assert_equal 2, /\x82/n =~ "あ"
 end
 
 assert('OnigRegexp.version') do


### PR DESCRIPTION
I implemented none encoding option.
Most of the reasons why I made this PR is I want to compatible with CRuby.

# Example

```rb
a = /
# comment
\x82
/xn
p a =~ "あ"
```

Before

```
mruby-onig-regexp/mrblib/onig_regexp.rb:8: wrong number of arguments (ArgumentError)
```

After

```
2
```