### PR TITLE
Support object except String

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -168,14 +168,19 @@ onig_match_common(mrb_state* mrb, OnigRegex reg, mrb_value match_value, mrb_valu
 
 static mrb_value
 onig_regexp_match(mrb_state *mrb, mrb_value self) {
-  mrb_value str;
+  mrb_value str = mrb_nil_value();
   OnigRegex reg;
   mrb_int pos = 0;
 
-  mrb_get_args(mrb, "S|i", &str, &pos);
+  mrb_get_args(mrb, "o|i", &str, &pos);
   if (pos < 0 || (pos > 0 && pos >= RSTRING_LEN(str))) {
     return mrb_nil_value();
   }
+
+  if (mrb_nil_p(str)) {
+    return mrb_nil_value();
+  }
+  str = mrb_string_type(mrb, str);
 
   Data_Get_Struct(mrb, self, &mrb_onig_regexp_type, reg);
 


### PR DESCRIPTION
In CRuby, `Regexp#=~` and `Regexp#match` method return `nil` when argument is `nil`.

```
$ irb
irb(main):001:0> /a/ =~ nil
=> nil
irb(main):002:0> /a/.match(nil)
=> nil
```

I think, OnigRegexp should follow this behavior.