### PR TITLE
Support Kernel#=~

### DIFF
--- a/mrblib/onig_regexp.rb
+++ b/mrblib/onig_regexp.rb
@@ -128,6 +128,12 @@ class String
   end
 end
 
+module Kernel
+  def =~(_)
+    nil
+  end
+end
+
 Regexp = OnigRegexp unless Object.const_defined?(:Regexp)
 MatchData = OnigMatchData unless Object.const_defined? :MatchData
 


### PR DESCRIPTION
`Kernel#=~` method is not absolutely necessary.
But, It's compatible with CRuby.

```
$ irb
irb(main):001:0> nil =~ /a/
=> nil
irb(main):002:0> /a/ =~ nil
=> nil
```

`Kernel#=~` implements to mruby-core is good idea.
But, `Kernel#=~` doesn't include ISO.
And, It used with Regexp in most cases.

So, I propse this patch to mruby-onig-regexp repository.