### PR TITLE
Support Onigmo 6.0.0

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -96,8 +96,11 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
     cc.include_paths << oniguruma_dir
   end
 
-
-  if build.cc.respond_to? :search_header_path and build.cc.search_header_path 'oniguruma.h'
+  if spec.respond_to? :search_package and spec.search_package 'onigmo'
+    spec.cc.defines += ['HAVE_ONIGMO_H']
+  elsif spec.respond_to? :search_package and spec.search_package 'oniguruma'
+    spec.cc.defines += ['HAVE_ONIGURUMA_H']
+  elsif build.cc.respond_to? :search_header_path and build.cc.search_header_path 'oniguruma.h'
     spec.linker.libraries << 'onig'
   else
     spec.bundle_onigmo

--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -35,7 +35,13 @@ THE SOFTWARE.
 #ifdef _MSC_VER
 #define ONIG_EXTERN extern
 #endif
+#ifdef HAVE_ONIGMO_H
+#include <onigmo.h>
+#elif defined(HAVE_ONIGURUMA_H)
+#include <oniguruma.h>
+#else
 #include "oniguruma.h"
+#endif
 
 #ifdef MRUBY_VERSION
 #define mrb_args_int mrb_int
@@ -946,7 +952,9 @@ mrb_mruby_onig_regexp_gem_init(mrb_state* mrb) {
   mrb_define_const(mrb, clazz, "CAPTURE_GROUP", mrb_fixnum_value(ONIG_OPTION_CAPTURE_GROUP));
   mrb_define_const(mrb, clazz, "NOTBOL", mrb_fixnum_value(ONIG_OPTION_NOTBOL));
   mrb_define_const(mrb, clazz, "NOTEOL", mrb_fixnum_value(ONIG_OPTION_NOTEOL));
+#ifdef ONIG_OPTION_POSIX_REGION
   mrb_define_const(mrb, clazz, "POSIX_REGION", mrb_fixnum_value(ONIG_OPTION_POSIX_REGION));
+#endif
 #ifdef ONIG_OPTION_ASCII_RANGE
   mrb_define_const(mrb, clazz, "ASCII_RANGE", mrb_fixnum_value(ONIG_OPTION_ASCII_RANGE));
 #endif


### PR DESCRIPTION
Onigmo changes header file name to onigmo.h from omiguruma.h since
6.0.0. ONIG_OPTION_POSIX_REGION is removed since 6.0.0.
See also: https://github.com/k-takata/Onigmo/blob/Onigmo-6.0.0/HISTORY

Gem::Specification#search_package was added in
https://github.com/mruby/mruby/commit/237d26fd86871cfd1e3531af87b1bf7654887bc3

It searches package information by pkg-config. For example,
spec.search_package('onigmo') searches onigmo.pc.