### PR TITLE
Fix compile option

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -94,9 +94,10 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
 
     file libmruby_a => Dir.glob("#{libonig_objs_dir}/*#{objext}") if File.exists? oniguruma_lib
 
-    file "#{dir}/src/mruby_onig_regexp.c" => oniguruma_lib
-    cc.include_paths << oniguruma_dir
-    cc.defines += ['HAVE_ONIGMO_H']
+    file "#{dir}/src/mruby_onig_regexp.c" => oniguruma_lib do
+      cc.include_paths << oniguruma_dir
+      cc.defines += ['HAVE_ONIGMO_H']
+    end
   end
 
   if spec.respond_to? :search_package and spec.search_package 'onigmo'


### PR DESCRIPTION
I'm encountering build issue https://github.com/zzak/mruby-uri/pull/6
This CI failed https://travis-ci.org/zzak/mruby-uri/builds/207632177

mruby-uri dependent on mruby-onig-regexp.
But CI build_config.rb is no need to write mruby-onig-regexp here.

mruby's testing call `bundle_onigmo` twice. Because called [here](https://github.com/mruby/mruby/blob/4f43db862a19df01720f72cc91925a497c7d7f45/mrbgems/mruby-test/mrbgem.rake#L36).
Then, `mruby-onig-regexp` compile option resolved after(of cause `@onigmo_bundled == true`)
And then, compile option doesn't set (I don't know why resolved after...)

On the other hand, mruby's testing doesn't call `bundle_onigmo` twice when added both `conf.gem 'mruby-onig-regexp'` and `add_dependency 'mruby-onig-regexp'`(I don't know why too...)

I don't know that this is a good way.
How do you think?