### PR TITLE
Ignores a block if replace_expr supplied

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -680,7 +680,7 @@ string_gsub(mrb_state* mrb, mrb_value self) {
   }
 
   if(!mrb_nil_p(blk) && !mrb_nil_p(replace_expr)) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "both block and replace expression must not be passed");
+    blk = mrb_nil_value();
   }
 
   OnigRegex reg;


### PR DESCRIPTION
I think, Most users of mruby expect behavior same as CRuby.

```
$ mruby -e 'p "food".gsub(/f/, "g") { "w" }'
trace:
	[0] -e:1
-e:1: both block and replace expression must not be passed (ArgumentError)
```

```
$ ruby -e 'p "food".gsub(/f/, "g") { "w" }'
"good"
```

See also https://github.com/ruby/spec/blob/0fe99d24f4a17eaa39563623209747eee278c3d1/core/string/gsub_spec.rb#L52