### PR TITLE
Shouldn't raise IndexError

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -649,11 +649,9 @@ append_replace_str(mrb_state* mrb, mrb_value result, mrb_value replace,
       default:
         if (isdigit(*ch)) { // group number 0-9
           int const idx = *ch - '0';
-          if (idx >= match->num_regs) {
-            mrb_raisef(mrb, E_INDEX_ERROR, "undefined group number reference: %S (max: %S)",
-                       mrb_fixnum_value(idx), mrb_fixnum_value(match->num_regs));
+          if (idx < match->num_regs) {
+            mrb_str_cat(mrb, result, RSTRING_PTR(src) + match->beg[idx], match->end[idx] - match->beg[idx]);
           }
-          mrb_str_cat(mrb, result, RSTRING_PTR(src) + match->beg[idx], match->end[idx] - match->beg[idx]);
         } else {
           char const str[] = { '\\', *ch };
           mrb_str_cat(mrb, result, str, 2);

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -257,8 +257,8 @@ assert('String#onig_regexp_gsub') do
   assert_equal 'h e l l o  m r u b y ', test_str.onig_regexp_gsub(OnigRegexp.new('\w')) { |v| v + ' ' }
   assert_equal 'h{e}ll{o} mr{u}by', test_str.onig_regexp_gsub(OnigRegexp.new('(?<hoge>[aeiou])'), '{\k<hoge>}')
   assert_equal '.h.e.l.l.o. .m.r.u.b.y.', test_str.onig_regexp_gsub(OnigRegexp.new(''), '.')
-  assert_raise(IndexError) { test_str.onig_regexp_gsub(OnigRegexp.new('(mruby)'), '<\2>') }
   assert_equal " hello\n mruby", "hello\nmruby".onig_regexp_gsub(OnigRegexp.new('^'), ' ')
+  assert_equal "he<l><><l><>o mruby", test_str.onig_regexp_gsub(OnigRegexp.new('(l)'), '<\1><\2>')
 end
 
 assert('String#onig_regexp_scan') do


### PR DESCRIPTION
Treats \1 sequences without corresponding captures as empty strings.

See also https://github.com/ruby/spec/blob/0fe99d24f4a17eaa39563623209747eee278c3d1/core/string/gsub_spec.rb#L89-L98