### PR TITLE
Fix infinity loop

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -767,7 +767,21 @@ string_scan(mrb_state* mrb, mrb_value self) {
       }
     }
 
-    last_end_pos = m->end[0];
+    if (m->beg[0] == m->end[0]) {
+      /*
+      * Always consume at least one character of the input string
+      */
+      if (RSTRING_LEN(self) > m->end[0]) {
+        char* p = RSTRING_PTR(self) + last_end_pos;
+        char* e = p + RSTRING_LEN(self);
+        int len = utf8len(p, e);
+        last_end_pos = m->end[0] + len;
+      } else {
+        last_end_pos = m->end[0] + 1;
+      }
+    } else {
+      last_end_pos = m->end[0];
+    }
   }
 
   return result;

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -275,6 +275,9 @@ assert('String#onig_regexp_scan') do
   result = ''
   assert_equal test_str, test_str.onig_regexp_scan(OnigRegexp.new('(.)(.)')) { |x, y| result += y; result += x }
   assert_equal 'rmbu yowlr', result
+
+  assert_equal [""] * (test_str.length + 1), test_str.onig_regexp_scan(OnigRegexp.new(''))
+  assert_equal [""], "".onig_regexp_scan(OnigRegexp.new(''))
 end
 
 assert('String#onig_regexp_sub') do


### PR DESCRIPTION
```rb
"hello".scan(//)
# Expect => ["", "", "", "", "", ""]
# Actual => infinity loop
```

References
- https://github.com/ruby/ruby/blob/f8d01bcb5729665acb32b0402b6781109b93d20f/string.c#L8509-L8522
- https://github.com/ruby/spec/blob/3f050297c149098849be35a3ff495a0afc7c45c2/core/string/scan_spec.rb#L19-L20