### PR TITLE
Raise ArgumentError instead of SIGABRT

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -866,6 +866,10 @@ string_sub(mrb_state* mrb, mrb_value self) {
     return mrb_funcall_with_block(mrb, self, mrb_intern_lit(mrb, "string_sub"), argc, argv, blk);
   }
 
+  if(argc == 1 && mrb_nil_p(blk)) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (given 1, expected 2)");
+  }
+
   if(!mrb_nil_p(blk) && !mrb_nil_p(replace_expr)) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "both block and replace expression must not be passed");
   }

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -286,6 +286,7 @@ assert('String#onig_regexp_sub') do
   assert_equal 'h<e>llo mruby', test_str.onig_regexp_sub(OnigRegexp.new('([aeiou])'), '<\1>')
   assert_equal 'h ello mruby', test_str.onig_regexp_sub(OnigRegexp.new('\w')) { |v| v + ' ' }
   assert_equal 'h{e}llo mruby', test_str.onig_regexp_sub(OnigRegexp.new('(?<hoge>[aeiou])'), '{\k<hoge>}')
+  assert_raise(ArgumentError) { "".onig_regexp_sub(OnigRegexp.new('')) }
 end
 
 assert('String#onig_regexp_split') do


### PR DESCRIPTION
```rb
"".sub(//)
# Expect => wrong number of arguments (given 1, expected 2) (ArgumentError)
# Actual => Assertion failed: (((replace).tt == MRB_TT_STRING)), function append_replace_str
```