### PR TITLE
Support to return Enumerator instead of SIGABRT

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -677,6 +677,10 @@ string_gsub(mrb_state* mrb, mrb_value self) {
     return mrb_funcall_with_block(mrb, self, mrb_intern_lit(mrb, "string_gsub"), argc, argv, blk);
   }
 
+  if(argc == 1 && mrb_nil_p(blk)) {
+    return mrb_funcall(mrb, self, "to_enum", 2, mrb_symbol_value(mrb_intern_lit(mrb, "onig_regexp_gsub")), match_expr);
+  }
+
   if(!mrb_nil_p(blk) && !mrb_nil_p(replace_expr)) {
     blk = mrb_nil_value();
   }


### PR DESCRIPTION
```rb
"".gsub(//)
# Expect => #<Enumerator: "":gsub(//)>
# Actual => Assertion failed: (((replace).tt == MRB_TT_STRING)), function append_replace_str
```

ref: https://github.com/mruby/mruby/blob/3703aed7ab7c056ef7a58fd8d25b84b59f715dad/mrblib/string.rb#L61