### PR TITLE
Ignore block instead of raising an ArgumentError

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -867,7 +867,7 @@ string_sub(mrb_state* mrb, mrb_value self) {
   }
 
   if(!mrb_nil_p(blk) && !mrb_nil_p(replace_expr)) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "both block and replace expression must not be passed");
+    blk = mrb_nil_value();
   }
 
   OnigRegex reg;

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -286,6 +286,7 @@ assert('String#onig_regexp_sub') do
   assert_equal 'h<e>llo mruby', test_str.onig_regexp_sub(OnigRegexp.new('([aeiou])'), '<\1>')
   assert_equal 'h ello mruby', test_str.onig_regexp_sub(OnigRegexp.new('\w')) { |v| v + ' ' }
   assert_equal 'h{e}llo mruby', test_str.onig_regexp_sub(OnigRegexp.new('(?<hoge>[aeiou])'), '{\k<hoge>}')
+  assert_equal "heOlo mruby", test_str.onig_regexp_sub(OnigRegexp.new("l"), "O") { "X" }
 end
 
 assert('String#onig_regexp_split') do


### PR DESCRIPTION
```rb
"a".sub(/a/, "o"){"x"}
# Expect(CRuby) => "o"
# Actual        => both block and replace expression must not be passed (ArgumentError)
```