### PR TITLE
Fix segmentation fault

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -829,7 +829,8 @@ string_split(mrb_state* mrb, mrb_value self) {
   }
 
   if(mrb_data_check_get_ptr(mrb, pattern, &mrb_onig_regexp_type) == NULL) {
-    if (!mrb_nil_p(pattern) && RSTRING_LEN(pattern) == 0) {
+    if(!mrb_nil_p(pattern)) { pattern = mrb_string_type(mrb, pattern); }
+    if(mrb_string_p(pattern) && RSTRING_LEN(pattern) == 0) {
       char* p = RSTRING_PTR(self);
       char* e = p + RSTRING_LEN(self);
       int n = 0;

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -341,6 +341,13 @@ assert('String#onig_regexp_split') do
   assert_equal ['1', '', '2', '3', '', '4', '', ''], test_str.onig_regexp_split(OnigRegexp.new(','), -4)
 
   assert_equal [], ''.onig_regexp_split(OnigRegexp.new(','), -1)
+
+  o = Object.new
+  def o.to_str
+    ","
+  end
+  assert_equal ["こ", "に", "ち", "わ"], "こ,に,ち,わ".onig_regexp_split(o)
+  assert_raise(TypeError) { "".onig_regexp_split(1) }
 end
 
 assert('String#index') do


### PR DESCRIPTION
```
"".split(1)
#=> segmentation fault
```

I think, it should delegate to core if argument is none OnigRegexp object.