### PR TITLE
Should use copied pointer

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -831,7 +831,7 @@ string_split(mrb_state* mrb, mrb_value self) {
   if(mrb_data_check_get_ptr(mrb, pattern, &mrb_onig_regexp_type) == NULL) {
     if(!mrb_nil_p(pattern)) { pattern = mrb_string_type(mrb, pattern); }
     if(mrb_string_p(pattern) && RSTRING_LEN(pattern) == 0) {
-      char* p = RSTRING_PTR(self);
+      char* p = mrb_str_to_cstr(mrb, self);
       char* e = p + RSTRING_LEN(self);
       int n = 0;
       result = mrb_ary_new(mrb);


### PR DESCRIPTION
`str_substr()` have a possibility to call `realloc()` when none embed string.

Then, The `p` will have a freed(realloced) pointer.

### The repro code. 

build_config.rb
```rb
MRuby::Build.new do |conf|
  toolchain :gcc
  enable_debug
  conf.gembox 'full-core'
  conf.gem mgem: "mruby-onig-regexp"
  conf.cc.flags << '-fsanitize=address'
  conf.linker.flags << '-fsanitize=address'
end
```

```rb
$ mruby -e '["aa"].join.split("")'
=================================================================
==9995==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d0000342b1 at pc 0x000101571898 bp 0x7fff5e976f50 sp 0x7fff5e976f48
READ of size 1 at 0x60d0000342b1 thread T0
    #0 0x101571897 in utf8len mruby_onig_regexp.c:71
    #1 0x1015612ab in string_split mruby_onig_regexp.c:839
    #2 0x1013ef7d8 in mrb_vm_exec (mruby:x86_64+0x1001707d8)
    #3 0x1013e4989 in mrb_vm_run (mruby:x86_64+0x100165989)
    #4 0x101417299 in mrb_top_run (mruby:x86_64+0x100198299)
    #5 0x101467dee in mrb_load_exec (mruby:x86_64+0x1001e8dee)
    #6 0x1014680c8 in mrb_load_nstring_cxt (mruby:x86_64+0x1001e90c8)
    #7 0x101468163 in mrb_load_string_cxt (mruby:x86_64+0x1001e9163)
    #8 0x101281a21 in main mruby.c:232
    #9 0x7fff9f476254 in start (libdyld.dylib:x86_64+0x5254)

0x60d0000342b1 is located 1 bytes inside of 129-byte region [0x60d0000342b0,0x60d000034331)
freed by thread T0 here:
    #0 0x101842520 in wrap_realloc (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x56520)
    #1 0x101379745 in mrb_default_allocf (mruby:x86_64+0x1000fa745)
    #2 0x1012faf48 in mrb_realloc_simple gc.c:202
    #3 0x1012fb62e in mrb_realloc gc.c:216
    #4 0x1013b0557 in str_make_shared (mruby:x86_64+0x100131557)
    #5 0x1013b0f51 in byte_subseq (mruby:x86_64+0x100131f51)
    #6 0x1013895f6 in str_substr (mruby:x86_64+0x10010a5f6)
    #7 0x101388c73 in mrb_str_substr (mruby:x86_64+0x100109c73)
    #8 0x10156e2e3 in str_substr mruby_onig_regexp.c:104
    #9 0x1015613b6 in string_split mruby_onig_regexp.c:840
    #10 0x1013ef7d8 in mrb_vm_exec (mruby:x86_64+0x1001707d8)
    #11 0x1013e4989 in mrb_vm_run (mruby:x86_64+0x100165989)
    #12 0x101417299 in mrb_top_run (mruby:x86_64+0x100198299)
    #13 0x101467dee in mrb_load_exec (mruby:x86_64+0x1001e8dee)
    #14 0x1014680c8 in mrb_load_nstring_cxt (mruby:x86_64+0x1001e90c8)
    #15 0x101468163 in mrb_load_string_cxt (mruby:x86_64+0x1001e9163)
    #16 0x101281a21 in main mruby.c:232
    #17 0x7fff9f476254 in start (libdyld.dylib:x86_64+0x5254)

previously allocated by thread T0 here:
    #0 0x101842520 in wrap_realloc (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x56520)
    #1 0x101379745 in mrb_default_allocf (mruby:x86_64+0x1000fa745)
    #2 0x1012faf48 in mrb_realloc_simple gc.c:202
    #3 0x1012fb62e in mrb_realloc gc.c:216
    #4 0x1012fc0b3 in mrb_malloc gc.c:237
    #5 0x10137c85c in mrb_str_buf_new (mruby:x86_64+0x1000fd85c)
    #6 0x10128ed83 in join_ary array.c:1036
    #7 0x10128e342 in mrb_ary_join array.c:1084
    #8 0x101297ab6 in mrb_ary_join_m array.c:1104
    #9 0x1013ef7d8 in mrb_vm_exec (mruby:x86_64+0x1001707d8)
    #10 0x1013e4989 in mrb_vm_run (mruby:x86_64+0x100165989)
    #11 0x101417299 in mrb_top_run (mruby:x86_64+0x100198299)
    #12 0x101467dee in mrb_load_exec (mruby:x86_64+0x1001e8dee)
    #13 0x1014680c8 in mrb_load_nstring_cxt (mruby:x86_64+0x1001e90c8)
    #14 0x101468163 in mrb_load_string_cxt (mruby:x86_64+0x1001e9163)
    #15 0x101281a21 in main mruby.c:232
    #16 0x7fff9f476254 in start (libdyld.dylib:x86_64+0x5254)

SUMMARY: AddressSanitizer: heap-use-after-free mruby_onig_regexp.c:71 in utf8len
Shadow bytes around the buggy address:
  0x1c1a00006800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c1a00006810: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c1a00006820: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c1a00006830: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c1a00006840: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x1c1a00006850: fa fa fa fa fa fa[fd]fd fd fd fd fd fd fd fd fd
  0x1c1a00006860: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
  0x1c1a00006870: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c1a00006880: 01 fa fa fa fa fa fa fa fa fa 00 00 00 00 00 00
  0x1c1a00006890: 00 00 00 00 00 00 00 00 00 00 01 fa fa fa fa fa
  0x1c1a000068a0: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==9995==ABORTING
SIGABRT from
-e:1
```