### PR TITLE
String#split more compatibility with CRuby

### DIFF
--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -364,11 +364,17 @@ assert('String#onig_regexp_split') do
   assert_equal ["h", "el", "lo"], "hello".onig_regexp_split(OnigRegexp.new('(el)|(xx)'))
 
   assert_equal ['あ', 'い', 'う', 'え', 'お'], 'あいうえお'.onig_regexp_split('')
+  assert_equal ['あ', 'い', 'う', 'え', 'お', ''], 'あいうえお'.onig_regexp_split('', -1)
   assert_equal ['あいうえお'], 'あいうえお'.onig_regexp_split('', 1)
   assert_equal ['あ', 'いうえお'], 'あいうえお'.onig_regexp_split('', 2)
   assert_equal ['あ', 'い', 'うえお'], 'あいうえお'.onig_regexp_split('', 3)
+
   assert_equal ['あ', 'い', 'う', 'え', 'お'], 'あいうえお'.onig_regexp_split(OnigRegexp.new(''))
   assert_equal ['あ', 'い', 'う', 'え', 'お', ''], 'あいうえお'.onig_regexp_split(OnigRegexp.new(''), -1)
+  assert_equal ['あいうえお'], 'あいうえお'.onig_regexp_split(OnigRegexp.new(''), 1)
+  assert_equal ['あ', 'いうえお'], 'あいうえお'.onig_regexp_split(OnigRegexp.new(''), 2)
+  assert_equal ['あ', 'い', 'うえお'], 'あいうえお'.onig_regexp_split(OnigRegexp.new(''), 3)
+
   assert_equal ['h', 'e', 'llo'], 'hello'.onig_regexp_split(OnigRegexp.new(''), 3)
   assert_equal ['h', 'i', 'd', 'a', 'd'], 'hi dad'.onig_regexp_split(OnigRegexp.new('\s*'))
 

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -359,10 +359,16 @@ assert('String#onig_regexp_split') do
   $; = prev_splitter
 
   assert_equal ['h', 'e', 'l', 'l', 'o'], 'hello'.onig_regexp_split(OnigRegexp.new(''))
+  assert_equal ["h", "e", "l", "l", "o", ""], 'hello'.onig_regexp_split(OnigRegexp.new(''), -1)
+  assert_equal ["h", "", "i", "", "!", "", ""], "hi!".onig_regexp_split(OnigRegexp.new('()'), -1)
+  assert_equal ["h", "el", "lo"], "hello".onig_regexp_split(OnigRegexp.new('(el)|(xx)'))
+
   assert_equal ['あ', 'い', 'う', 'え', 'お'], 'あいうえお'.onig_regexp_split('')
   assert_equal ['あいうえお'], 'あいうえお'.onig_regexp_split('', 1)
   assert_equal ['あ', 'いうえお'], 'あいうえお'.onig_regexp_split('', 2)
   assert_equal ['あ', 'い', 'うえお'], 'あいうえお'.onig_regexp_split('', 3)
+  assert_equal ['あ', 'い', 'う', 'え', 'お'], 'あいうえお'.onig_regexp_split(OnigRegexp.new(''))
+  assert_equal ['あ', 'い', 'う', 'え', 'お', ''], 'あいうえお'.onig_regexp_split(OnigRegexp.new(''), -1)
   assert_equal ['h', 'e', 'llo'], 'hello'.onig_regexp_split(OnigRegexp.new(''), 3)
   assert_equal ['h', 'i', 'd', 'a', 'd'], 'hi dad'.onig_regexp_split(OnigRegexp.new('\s*'))
 


### PR DESCRIPTION
String#split with Regexp:
- [splits between characters when regexp matches a zero-length string](https://github.com/ruby/spec/blob/7214c655540b60e2120849c5cfce6d1910b8ca3a/core/string/split_spec.rb#L263-L278)
- [includes all captures in the result array](https://github.com/ruby/spec/blob/7214c655540b60e2120849c5cfce6d1910b8ca3a/core/string/split_spec.rb#L295-L301)
- [does not include non-matching captures in the result array](https://github.com/ruby/spec/blob/7214c655540b60e2120849c5cfce6d1910b8ca3a/core/string/split_spec.rb#L303-L305)