### PR TITLE
Global variables should set nil when ONIG_MISMATCH

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -184,7 +184,7 @@ onig_match_common(mrb_state* mrb, OnigRegex reg, mrb_value match_value, mrb_valu
   }
 
   struct RObject* const cls = (struct RObject*)mrb_class_get(mrb, "OnigRegexp");
-  mrb_obj_iv_set(mrb, cls, mrb_intern_lit(mrb, "@last_match"), match_value);
+  mrb_obj_iv_set(mrb, cls, mrb_intern_lit(mrb, "@last_match"), MISMATCH_NIL_OR(match_value));
 
   if (mrb_class_get(mrb, "Regexp") == (struct RClass*)cls &&
     mrb_bool(mrb_obj_iv_get(mrb, (struct RObject*)cls, mrb_intern_lit(mrb, "@set_global_variables"))))

--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -167,6 +167,8 @@ create_onig_region(mrb_state* mrb, mrb_value const str, mrb_value rex) {
   return c;
 }
 
+#define MISMATCH_NIL_OR(v) (result == ONIG_MISMATCH ? mrb_nil_value() : (v))
+
 static int
 onig_match_common(mrb_state* mrb, OnigRegex reg, mrb_value match_value, mrb_value str, int pos) {
   mrb_assert(mrb_string_p(str));
@@ -184,17 +186,19 @@ onig_match_common(mrb_state* mrb, OnigRegex reg, mrb_value match_value, mrb_valu
   struct RObject* const cls = (struct RObject*)mrb_class_get(mrb, "OnigRegexp");
   mrb_obj_iv_set(mrb, cls, mrb_intern_lit(mrb, "@last_match"), match_value);
 
-  if (result != ONIG_MISMATCH &&
-      mrb_class_get(mrb, "Regexp") == (struct RClass*)cls &&
-      mrb_bool(mrb_obj_iv_get(mrb, (struct RObject*)cls, mrb_intern_lit(mrb, "@set_global_variables"))))
+  if (mrb_class_get(mrb, "Regexp") == (struct RClass*)cls &&
+    mrb_bool(mrb_obj_iv_get(mrb, (struct RObject*)cls, mrb_intern_lit(mrb, "@set_global_variables"))))
   {
-    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$~"), match_value);
+    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$~"),
+               MISMATCH_NIL_OR(match_value));
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$&"),
-               mrb_funcall(mrb, match_value, "[]", 1, mrb_fixnum_value(0)));
-    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$`"), mrb_funcall(mrb, match_value, "pre_match", 0));
-    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$'"), mrb_funcall(mrb, match_value, "post_match", 0));
+               MISMATCH_NIL_OR(mrb_funcall(mrb, match_value, "[]", 1, mrb_fixnum_value(0))));
+    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$`"),
+               MISMATCH_NIL_OR(mrb_funcall(mrb, match_value, "pre_match", 0)));
+    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$'"),
+               MISMATCH_NIL_OR(mrb_funcall(mrb, match_value, "post_match", 0)));
     mrb_gv_set(mrb, mrb_intern_lit(mrb, "$+"),
-               mrb_funcall(mrb, match_value, "[]", 1, mrb_fixnum_value(match->num_regs - 1)));
+               MISMATCH_NIL_OR(mrb_funcall(mrb, match_value, "[]", 1, mrb_fixnum_value(match->num_regs - 1))));
 
     // $1 to $9
     int idx = 1;

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -159,6 +159,10 @@ def onig_match_data_example
   OnigRegexp.new('(\w+)(\w)').match('+aaabb-')
 end
 
+def onig_mismatch_data_example
+  OnigRegexp.new('abc').match('z')
+end
+
 assert('OnigMatchData.new') do
   assert_raise(NoMethodError) { OnigMatchData.new('aaa', 'i') }
 end
@@ -381,32 +385,58 @@ Regexp = OnigRegexp
 assert('$~') do
   m = onig_match_data_example
   assert_equal m[0], $~[0]
+
+  onig_mismatch_data_example
+  assert_nil $~
 end
 
 assert('$&') do
   m = onig_match_data_example
   assert_equal m[0], $&
+
+  onig_mismatch_data_example
+  assert_nil $&
 end
 
 assert('$`') do
   m = onig_match_data_example
   assert_equal m.pre_match, $`
+
+  onig_mismatch_data_example
+  assert_nil $`
 end
 
 assert('$\'') do
   m = onig_match_data_example
   assert_equal m.post_match, $'
+
+  onig_mismatch_data_example
+  assert_nil $'
 end
 
 assert('$+') do
   m = onig_match_data_example
   assert_equal m[-1], $+
+
+  onig_mismatch_data_example
+  assert_nil $+
 end
 
 assert('$1 to $9') do
   onig_match_data_example
   assert_equal 'aaab', $1
   assert_equal 'b', $2
+  assert_nil $3
+  assert_nil $4
+  assert_nil $5
+  assert_nil $6
+  assert_nil $7
+  assert_nil $8
+  assert_nil $9
+
+  onig_mismatch_data_example
+  assert_nil $1
+  assert_nil $2
   assert_nil $3
   assert_nil $4
   assert_nil $5

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -19,6 +19,9 @@ end
 assert('OnigRegexp.last_match', '15.2.15.6.3') do
   OnigRegexp.new('.*') =~ 'ginka'
   assert_equal 'ginka', OnigRegexp.last_match[0]
+
+  OnigRegexp.new('zzz') =~ 'ginka'
+  assert_nil OnigRegexp.last_match
 end
 
 assert('OnigRegexp.quote', '15.2.15.6.4') do


### PR DESCRIPTION
```rb
p /(b)/.match("abc") #=> #<OnigMatchData:0x62f000019440>
p $1 #=> "b"
p $~ #=> #<OnigMatchData:0x62f000019440>
p $` #=> "a"
p $' #=> "c"

# Then

## Actual
p /(b)/.match("abc") #=> nil
p $1 #=> "b"
p $~ #=> #<OnigMatchData:0x62f000019440>
p $` #=> "a"
p $' #=> "c"

## Expect
p /(b)/.match("") => nil
p $1 #=> nil
p $~ #=> nil
p $` #=> nil
p $' #=> nil
```