### PR TITLE
Fix to work regexp interpolation

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -312,7 +312,7 @@ regexp_expr_str(mrb_state *mrb, mrb_value str, const char *p, int len) {
     unsigned char c, cc;
 
     c = *p;
-    if (c == '/'|| c == '\\') {
+    if (c == '/') {
       buf[0] = '\\'; buf[1] = c;
       mrb_str_cat(mrb, str, buf, 2);
       continue;

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -98,6 +98,7 @@ assert("OnigRegexp#inspect") do
   assert_equal '/(https?:\/\/[^\/]+)[-a-zA-Z0-9.\/]+/', reg.inspect
   assert_equal '/abc\nd\te/mi', OnigRegexp.new("abc\nd\te", OnigRegexp::MULTILINE | OnigRegexp::IGNORECASE).inspect
   assert_equal '/abc/min', OnigRegexp.new("abc", OnigRegexp::MULTILINE | OnigRegexp::IGNORECASE, "none").inspect
+  assert_equal "/\\\\\\+\\//", /\\\+\//.inspect
 end
 
 assert("OnigRegexp#to_s") do
@@ -106,6 +107,7 @@ assert("OnigRegexp#to_s") do
   assert_equal '(?mx-i:ab+c)', OnigRegexp.new("ab+c", OnigRegexp::MULTILINE | OnigRegexp::EXTENDED).to_s
   assert_equal '(?mi-x:ab+c)', /ab+c/im.to_s
   assert_equal '(?mi-x:ab+c)', /ab+c/imn.to_s
+  assert_equal "(?-mix:\\\\\\+)", /\\\+/.to_s
 end
 
 assert("OnigRegexp#to_s (composition)") do
@@ -116,6 +118,10 @@ assert("OnigRegexp#to_s (composition)") do
   re3 = OnigRegexp.new("ab.+c", OnigRegexp::MULTILINE)
   re4 = OnigRegexp.new("xy#{re3}z", OnigRegexp::IGNORECASE)
   assert_equal '(?i-mx:xy(?m-ix:ab.+c)z)', re4.to_s
+
+  re5 = /\\\+/
+  re6 = /xy#{re5}z/
+  assert_equal "(?-mix:xy(?-mix:\\\\\\+)z)", re6.to_s
 end
 
 # Extended patterns.


### PR DESCRIPTION
See this example, it shows curious results:

```ruby
re = %r{#{/\[foo\]/}}
p re =~ "[foo]" # => nil (wtf?)
p re =~ "\\\\" # => 0 (wtf???)
```

Because `%r{#{/\[foo\]/}}` reproduces `/\\[foo\\]/` whose backslash is **double** escaped. This PR fixes not to escape backslash. I think it is no problem because valid regexp doesn't need to escape backslash and it cannot create such an invalid regexp (for instance `RegExp.new('\\')` causes an error.)