### PR TITLE
Support symbol value

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -219,6 +219,22 @@ onig_match_common(mrb_state* mrb, OnigRegex reg, mrb_value match_value, mrb_valu
 }
 
 static mrb_value
+reg_operand(mrb_state *mrb, mrb_value obj) {
+  mrb_value ret;
+
+  if (mrb_symbol_p(obj)) {
+    ret = mrb_sym2str(mrb, mrb_symbol(obj));
+    if (mrb_undef_p(ret)) {
+      mrb_bug(mrb, "can not intern %S", obj);
+    }
+  }
+  else {
+    ret = mrb_string_type(mrb, obj);
+  }
+  return ret;
+}
+
+static mrb_value
 onig_regexp_match(mrb_state *mrb, mrb_value self) {
   mrb_value str = mrb_nil_value();
   OnigRegex reg;
@@ -233,7 +249,7 @@ onig_regexp_match(mrb_state *mrb, mrb_value self) {
   if (mrb_nil_p(str)) {
     return mrb_nil_value();
   }
-  str = mrb_string_type(mrb, str);
+  str = reg_operand(mrb, str);
 
   Data_Get_Struct(mrb, self, &mrb_onig_regexp_type, reg);
 
@@ -264,7 +280,7 @@ onig_regexp_match_p(mrb_state *mrb, mrb_value self) {
   if (mrb_nil_p(str)) {
     return mrb_nil_value();
   }
-  str = mrb_string_type(mrb, str);
+  str = reg_operand(mrb, str);
 
   Data_Get_Struct(mrb, self, &mrb_onig_regexp_type, reg);
   str_ptr = (OnigUChar const*)RSTRING_PTR(str);

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -126,15 +126,23 @@ end
 
 # Extended patterns.
 assert("OnigRegexp#match (no flags)") do
+  o = Object.new
+  def o.to_str
+    "obj"
+  end
   [
     [ ".*", "abcd\nefg", "abcd" ],
     [ "^a.", "abcd\naefg", "ab" ],
     [ "^a.", "bacd\naefg", "ae" ],
-    [ ".$", "bacd\naefg", "d" ]
+    [ ".$", "bacd\naefg", "d" ],
+    [ "bc", :abc, "bc"],
+    [ "bj", o, "bj"],
   ].each do |reg, str, result|
     m = OnigRegexp.new(reg).match(str)
     assert_equal result, m[0] if assert_false m.nil?
   end
+
+  assert_raise(TypeError) { /a/.match(Object.new) }
 end
 
 assert("OnigRegexp#match (multiline)") do
@@ -500,6 +508,7 @@ end
 
 assert('OnigRegexp#match?') do
   assert_false OnigRegexp.new('^[123]+$').match?('abc')
+  assert_false OnigRegexp.new('^[123]+$').match?(:abc)
   assert_true OnigRegexp.new('^[123]+$').match?('321')
   assert_true OnigRegexp.new('webp').match?('text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8')
   assert_true(/webp/.match?('text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8'))


### PR DESCRIPTION
for `Regexp#match` `Regexp#match?` and `Regexp#=~`

```
$ irb
irb(main):001:0> /(.)(.)(.)/.match(:abc)
=> #<MatchData "abc" 1:"a" 2:"b" 3:"c">
```