### PR TITLE
Should not raise TypeError

### DIFF
--- a/mrblib/onig_regexp.rb
+++ b/mrblib/onig_regexp.rb
@@ -23,6 +23,8 @@ class OnigRegexp
   # ISO 15.2.15.7.4
   def ===(str)
     not self.match(str).nil?
+  rescue TypeError
+    false
   end
 
   # ISO 15.2.15.7.5

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -54,6 +54,8 @@ assert("OnigRegexp#===", '15.2.15.7.4') do
   reg = OnigRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+")
   assert_true reg === "http://example.com"
   assert_false reg === "htt://example.com"
+
+  assert_false /a/ === Object.new
 end
 
 assert('OnigRegexp#=~', '15.2.15.7.5') do


### PR DESCRIPTION
I think, It doesn't expect to raise TypeError in  this case.

```rb
o = Object.new # some object
case o
when /aaa/
  # ...
when /bbb/
  # ...
when ...
end
```

And CRuby doesn't too.