### PR TITLE
Fix SEGV when `/abc/.match(nil, 1)`

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -242,14 +242,13 @@ onig_regexp_match(mrb_state *mrb, mrb_value self) {
   mrb_value block = mrb_nil_value();
 
   mrb_get_args(mrb, "o|i&", &str, &pos, &block);
-  if (pos < 0 || (pos > 0 && pos >= RSTRING_LEN(str))) {
-    return mrb_nil_value();
-  }
-
   if (mrb_nil_p(str)) {
     return mrb_nil_value();
   }
   str = reg_operand(mrb, str);
+  if (pos < 0 || (pos > 0 && pos >= RSTRING_LEN(str))) {
+    return mrb_nil_value();
+  }
 
   Data_Get_Struct(mrb, self, &mrb_onig_regexp_type, reg);
 
@@ -273,14 +272,13 @@ onig_regexp_match_p(mrb_state *mrb, mrb_value self) {
   OnigUChar const* str_ptr;
 
   mrb_get_args(mrb, "o|i", &str, &pos);
-  if (pos < 0 || (pos > 0 && pos >= RSTRING_LEN(str))) {
-    return mrb_nil_value();
-  }
-
   if (mrb_nil_p(str)) {
     return mrb_nil_value();
   }
   str = reg_operand(mrb, str);
+  if (pos < 0 || (pos > 0 && pos >= RSTRING_LEN(str))) {
+    return mrb_nil_value();
+  }
 
   Data_Get_Struct(mrb, self, &mrb_onig_regexp_type, reg);
   str_ptr = (OnigUChar const*)RSTRING_PTR(str);

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -75,6 +75,12 @@ assert("OnigRegexp#match", '15.2.15.7.7') do
   reg = OnigRegexp.new("(https?://[^/]+)[-a-zA-Z0-9./]+")
   assert_false reg.match("http://masamitsu-murase.12345/hoge.html").nil?
   assert_nil reg.match("http:///masamitsu-murase.12345/hoge.html")
+
+  reg = OnigRegexp.new('def')
+  assert_equal "def", reg.match('abcdef', 3)[0]
+  assert_nil reg.match('abcdef', -1)
+  assert_nil reg.match('abcdef', 4)
+  assert_nil reg.match(nil, 3)
 end
 
 assert("OnigRegexp#source", '15.2.15.7.8') do
@@ -514,6 +520,12 @@ assert('OnigRegexp#match?') do
   assert_true OnigRegexp.new('^[123]+$').match?('321')
   assert_true OnigRegexp.new('webp').match?('text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8')
   assert_true(/webp/.match?('text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8'))
+
+  reg = OnigRegexp.new('def')
+  assert_true reg.match?('abcdef', 3)
+  assert_false reg.match?('abcdef', -1)
+  assert_false reg.match?('abcdef', 4)
+  assert_false reg.match?(nil, 3)
 end
 
 assert('String#match?') do


### PR DESCRIPTION
I found clash case because it call `RSTRING_LEN()` macro with `nil` object.

```
`/abc/.match(nil, 1)`
`/abc/.match?(nil, 1)`
```