### PR TITLE
Recent mruby doesn't provide String#scan

### DIFF
--- a/mrblib/onig_regexp.rb
+++ b/mrblib/onig_regexp.rb
@@ -49,10 +49,8 @@ class String
 
   # redefine methods with oniguruma regexp version
   %i[sub gsub split scan].each do |v|
-    if respond_to? v
-      alias_method :"string_#{v}", v
-      alias_method v, :"onig_regexp_#{v}"
-    end
+    alias_method :"string_#{v}", v if method_defined?(v)
+    alias_method v, :"onig_regexp_#{v}"
   end
 
   alias_method :match?, :onig_regexp_match?


### PR DESCRIPTION
https://github.com/mruby/mruby/commit/cdb458ed4e07698ecb028bfe397fa273ed454e13

Error message:

```text
trace (most recent call last):
	[0] /home/travis/build/kou/mruby-onig-regexp/mrblib/onig_regexp.rb:40
	[1] /home/travis/build/kou/mruby-onig-regexp/mrblib/onig_regexp.rb:51
	[2] /home/travis/build/kou/mruby-onig-regexp/mruby/mrblib/array.rb:18:in each
	[3] /home/travis/build/kou/mruby-onig-regexp/mrblib/onig_regexp.rb:52:in call
/home/travis/build/kou/mruby-onig-regexp/mrblib/onig_regexp.rb:52: undefined method 'scan' for class String (NameError)
```

https://travis-ci.org/kou/mruby-onig-regexp/builds/524317605#L4704