### PR TITLE
Add String#match

### DIFF
--- a/mrblib/onig_regexp.rb
+++ b/mrblib/onig_regexp.rb
@@ -47,6 +47,14 @@ class String
     end
   end
 
+  # ISO 15.2.10.5.27
+  unless method_defined?(:match)
+    def match(re, pos=0, &block)
+      re.match(self, pos, &block)
+    end
+  end
+
+
   # redefine methods with oniguruma regexp version
   %i[sub gsub split scan].each do |v|
     alias_method :"string_#{v}", v if method_defined?(v)

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -404,6 +404,17 @@ assert('String#onig_regexp_split') do
   assert_raise(TypeError) { "".onig_regexp_split(1) }
 end
 
+assert('String#onig_regexp_match') do
+  reg = OnigRegexp.new('d(e)f')
+  assert_equal ['def', 'e'], 'abcdef'.match(reg).to_a
+  assert_nil 'abcdef'.match(reg, 4)
+  match_data = nil
+  'abcdef'.match(reg) do |m|
+    match_data = m
+  end
+  assert_equal ['def', 'e'], match_data.to_a
+end
+
 assert('String#index') do
   assert_equal 0, 'abc'.index('a')
   assert_nil 'abc'.index('d')


### PR DESCRIPTION
Because mruby removes String#match at
https://github.com/mruby/mruby/commit/fd37bc53deb2d52fe3134838eab002dfb9ac35ab .