### PR TITLE
Always define String#match

### DIFF
--- a/mrblib/onig_regexp.rb
+++ b/mrblib/onig_regexp.rb
@@ -52,10 +52,8 @@ class String
   end
 
   # ISO 15.2.10.5.27
-  unless method_defined?(:match)
-    def match(re, pos=0, &block)
-      re.match(self, pos, &block)
-    end
+  def match(re, pos=0, &block)
+    re.match(self, pos, &block)
   end
 
 


### PR DESCRIPTION
Seems it's failing from 2.0.0～.
`String#match` in core doesn't handle second argument so should be overwritten.