### PR TITLE
Prefer MRuby::CrossBuild#host_target if specified

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -61,7 +61,7 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
           'AR' => build.archiver.command }
         unless ENV['OS'] == 'Windows_NT'
           if build.kind_of? MRuby::CrossBuild
-            host = "--host #{build.name}"
+            host = "--host #{build.host_target ? build.host_target : build.name}"
           end
 
           _pp 'autotools', oniguruma_dir


### PR DESCRIPTION
It seems that `MRuby::CrossBuild#host_target` is meant for configuring things like this `--host` option https://github.com/mruby/mruby/blob/2.0.1/lib/mruby/build.rb#L357-L359.

It'd be nice if mruby-onig-regexp also respects that attribute for consistency with libraries like [mruby-yaml](https://github.com/mrbgems/mruby-yaml/blob/0606652a6e99d902cd3101cf2d757a7c0c37a7fd/mrbgem.rake#L49). Because this attr is not set by default, I believe this is almost always backward compatible.