### PR TITLE
Don't require libpthread when cross-compiling

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -12,7 +12,7 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
     require 'open3'
 
     # remove libonig, instead link directly against pthread
-    unless ENV['OS'] == 'Windows_NT'
+    unless ENV['OS'] == 'Windows_NT' || build.kind_of?(MRuby::CrossBuild)
       linker.libraries = ['pthread']
     end
 


### PR DESCRIPTION
ENV['OS'] might not indicate the correct target environment.  Rely instead on the configuration file to provide libpthread if it is needed.

I've successfully cross-compiled mruby for FreeDOS and would like to include this gem in the configuration. It needs this change because DJGPP does not provide or need pthread.