### PR TITLE
Optionally always use the included libonig sources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ MRuby::Build.new do |conf|
 end
 ```
 
+If `libonig` is already installed on your system, the gem will use it;
+otherwise, it will build a local copy from source code and statically
+link to it.
+
+You can force the gem to always use its own version of the library by
+setting `MRUBY_ONIGMO_USE_INTERNAL=1` in the environment.
+
+
 ## Example
 ```ruby
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,48 @@
+# Rakefile for gem development.
+
+MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || "dev_build_config.rb")
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "stable"
+
+# Rule to check out the mruby sources indicated in MRUBY_VERSION to
+# use for gem development.
+file :mruby do
+  # If we're using one of the common branches, we can clone it
+  # directly and also skip a lot of the history, letting us save some
+  # bandwidth.  Otherwise, we need to fetch the whole thing and then
+  # checkout the desired commit.
+
+  common_branch = %w{master stable}.include?(MRUBY_VERSION)
+  depth = "--depth=1 --branch=#{MRUBY_VERSION}" if common_branch
+
+  sh "git clone #{depth} https://github.com/mruby/mruby.git"
+  unless common_branch
+    Dir.chdir 'mruby' do
+      sh "git fetch --tags"
+      rev = %x{git rev-parse #{MRUBY_VERSION}}
+      sh "git checkout #{rev}"
+    end
+  end
+end
+
+desc "compile binary"
+task :compile => :mruby do
+  sh "cd mruby && rake all MRUBY_CONFIG=#{MRUBY_CONFIG}"
+end
+
+desc "test"
+task :test => :mruby do
+  sh "cd mruby && rake all test MRUBY_CONFIG=#{MRUBY_CONFIG}"
+end
+
+desc "cleanup"
+task :clean do
+  sh "cd mruby && rake deep_clean" if File.directory?('mruby')
+  sh "rm -rf *.lock test_support/*.mrb tools_ruby/*/*.mrb"
+end
+
+task :default => :compile
+
+desc "thorough cleanup; gemdev only"
+task :spotless => :clean do
+  sh "rm -rf mruby *.lock"
+end

--- a/dev_build_config.rb
+++ b/dev_build_config.rb
@@ -1,0 +1,19 @@
+MRuby::Build.new do |conf|
+
+  conf.disable_presym
+
+  conf.toolchain()
+
+  conf.gembox 'default'
+  conf.gem core: 'mruby-bin-debugger'
+  conf.gem File.expand_path(File.dirname(__FILE__))
+
+  conf.enable_debug
+
+  conf.enable_test
+  conf.enable_bintest
+
+  if ENV['DEBUG'] == 'true'
+    conf.cc.defines = %w(MRB_ENABLE_DEBUG_HOOK)
+  end
+end


### PR DESCRIPTION
By default, the build process will check if libonig has already been installed and if so, use that.  Otherwise, it will compile the copy included with the gem and use that instead.

This is not always desirable, e.g. when compiling a redistributable program that can't be shipped with the shared library.

With this change, if environment variable MRUBY_ONIGMO_USE_INTERNAL is set and not empty, the build process will always use the included library regardless of what else is available.

(This change also adds a Rakefile and build_config.rb that will build mruby in the current directory and add this gem to it.  This is a development aid.)

(This is related to https://github.com/mattn/mruby-onig-regexp/issues/110)