### PR TITLE
Avoid using mrb_bug()

### DIFF
--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -228,9 +228,6 @@ reg_operand(mrb_state *mrb, mrb_value obj) {
 
   if (mrb_symbol_p(obj)) {
     ret = mrb_sym2str(mrb, mrb_symbol(obj));
-    if (mrb_undef_p(ret)) {
-      mrb_bug(mrb, "can not intern %S", obj);
-    }
   }
   else {
     ret = mrb_string_type(mrb, obj);


### PR DESCRIPTION
Recently, mrb_bug() signature was changed:
https://github.com/mruby/mruby/commit/82a48bd4559eac269a7575522a693c9a278531a6

So we can't build this mrbgem with the latest mruby:

    CC    ../mruby-build/repos/host/mruby-onig-regexp/src/mruby_onig_regexp.c -> ../mruby-build/host/mrbgems/mruby-onig-regexp/src/mruby_onig_regexp.o
    mruby-build/repos/host/mruby-onig-regexp/src/mruby_onig_regexp.c: In function ‘reg_operand’:
    mruby-build/repos/host/mruby-onig-regexp/src/mruby_onig_regexp.c:228:7: error: too many arguments to function ‘mrb_bug’
      228 |       mrb_bug(mrb, "can not intern %S", obj);
          |       ^~~~~~~
    In file included from mruby-build/repos/host/mruby-onig-regexp/src/mruby_onig_regexp.c:28:
    mruby-source/include/mruby.h:1360:27: note: declared here
     1360 | MRB_API mrb_noreturn void mrb_bug(mrb_state *mrb, const char *mesg);
          |                           ^~~~~~~

We can follow the API change but how about removing the undef check instead? Because there is "can't happen" comment in `mrb_sym2str()` (`mrb_sym_str()`)  source:

https://github.com/mruby/mruby/blob/4810706ccc5e43ac84c967c200b60edae6a76f09/src/symbol.c#L618