### PR TITLE
Fix build error with mingw

### DIFF
--- a/fix-build-error-with-mingw.patch
+++ b/fix-build-error-with-mingw.patch
@@ -1,0 +1,14 @@
+--- a/onigmo-6.2.0/configure	2019-01-30 19:33:48.000000000 +0900
++++ b/onigmo-6.2.0/configure	2023-05-28 03:23:17.874370143 +0900
+@@ -9847,9 +9847,9 @@
+ 	# FIXME: Setting linknames here is a bad hack.
+ 	archive_cmds='$CC -o $lib $libobjs $compiler_flags `func_echo_all "$deplibs" | $SED '\''s/ -lc$//'\''` -link -dll~linknames='
+ 	# The linker will automatically build a .lib file if we build a DLL.
+-	old_archive_from_new_cmds='true'
++	#old_archive_from_new_cmds='true'
+ 	# FIXME: Should let the user specify the lib program.
+-	old_archive_cmds='lib -OUT:$oldlib$oldobjs$old_deplibs'
++	#old_archive_cmds='lib -OUT:$oldlib$oldobjs$old_deplibs'
+ 	enable_shared_with_static_runtimes=yes
+ 	;;
+       esac

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -39,6 +39,7 @@ MRuby::Gem::Specification.new('mruby-onig-regexp') do |spec|
       Dir.chdir(build_dir) do
         _pp 'extracting', "onigmo-#{version}"
         `gzip -dc "#{dir}/onigmo-#{version}.tar.gz" | tar xf -`
+        `patch -p1 < "#{dir}/fix-build-error-with-mingw.patch"`
       end
     end
 


### PR DESCRIPTION
@mattn 
When trying to build using mingw, a "lib not found" error occurs. 
see: https://github.com/mattn/mruby-onig-regexp/issues/105
