### PR TITLE
Handle non-Onig Regexp in String#split

### DIFF
--- a/.github/workflows/mrbgem.yml
+++ b/.github/workflows/mrbgem.yml
@@ -17,11 +17,9 @@ jobs:
         os: [ubuntu-22.04, macos-latest]
         mruby_version:
         - master
+        - 4.0.0
+        - 3.4.0
         - 3.3.0
-        - 3.2.0
-        - 3.1.0
-        # - 3.0.0
-        - 2.1.2
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} & mruby-${{ matrix.mruby_version }}
     env:

--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -995,6 +995,18 @@ string_split(mrb_state* mrb, mrb_value self) {
   }
 
   if (!ONIG_REGEXP_P(pattern)) {
+    /* When another Regexp implementation (e.g. mruby core mruby-regexp) is
+       present, a Regexp literal is not an OnigRegexp. Convert it via its
+       source so that split() still works instead of failing to coerce it
+       into a String. */
+    if(!mrb_nil_p(pattern) && !mrb_string_p(pattern) &&
+       mrb_respond_to(mrb, pattern, MRB_SYM(source))) {
+      mrb_value src = mrb_funcall_id(mrb, pattern, MRB_SYM(source), 0);
+      pattern = mrb_funcall_id(mrb, mrb_obj_value(cls_onig_regexp), MRB_SYM(new), 1, src);
+    }
+  }
+
+  if (!ONIG_REGEXP_P(pattern)) {
     if(!mrb_nil_p(pattern)) { pattern = mrb_string_type(mrb, pattern); }
     if(mrb_string_p(pattern) && RSTRING_LEN(pattern) == 0) {
       /* Special case - split into chars */

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -446,6 +446,15 @@ assert('String#onig_regexp_split') do
 
   assert_equal ["こ", "に", "ち", "わ"], "こ,に,ち,わ".onig_regexp_split(",")
   assert_raise(TypeError) { "".onig_regexp_split(1) }
+
+  # A Regexp literal can resolve to another Regexp implementation (e.g. mruby
+  # core mruby-regexp) when it is built alongside this gem. split must still
+  # accept it instead of trying to coerce it into a String.
+  assert_equal ['JP', 'US', ' UK'], 'JP,US, UK'.onig_regexp_split(/,/)
+  assert_equal [], ''.onig_regexp_split(/,/)
+  if Regexp != OnigRegexp
+    assert_equal ['JP', 'US', ' UK'], 'JP,US, UK'.onig_regexp_split(Regexp.new(','))
+  end
 end
 
 assert('String#onig_regexp_match') do


### PR DESCRIPTION
When mruby core's mruby-regexp gem is built alongside this gem, the `Regexp` constant refers to the core `Regexp` rather than `OnigRegexp`. In that case passing a Regexp literal to `String#split` (e.g. `str.split(/,/)`) failed because `string_split` tried to coerce it into a String, raising `Regexp cannot be converted to String` (or an arity error in the delegated `__split`, depending on the build). Now a non-Onig Regexp argument is converted into an OnigRegexp via its `source` so split keeps working; behavior for String, nil, and OnigRegexp arguments is unchanged.