### PR TITLE
Accept OnigRegexp in []/[]=/slice!/index when Regexp constant is foreign

### DIFF
--- a/mrblib/onig_regexp.rb
+++ b/mrblib/onig_regexp.rb
@@ -19,6 +19,22 @@ class OnigRegexp
     @last_match = match
   end
 
+  # True when +obj+ is usable as a regexp argument. This accepts both
+  # OnigRegexp and the (possibly distinct) core Regexp, since another Regexp
+  # implementation may define the Regexp constant when built alongside.
+  def self.regexp_arg?(obj)
+    obj.is_a?(OnigRegexp) || obj.is_a?(Regexp)
+  end
+
+  # Run the block while preserving OnigRegexp.last_match around it, so that
+  # mutating helpers (e.g. String#slice!) do not clobber the last match.
+  def self.preserving_last_match
+    lm = last_match
+    yield
+  ensure
+    self.last_match = lm
+  end
+
   # ISO 15.2.15.7.2
   def initialize_copy(other)
     initialize(other.source, other.options)
@@ -83,7 +99,7 @@ class String
   alias_method :old_square_brancket_equal, :[]=
 
   def [](*args)
-    return old_square_brancket(*args) unless args[0].class == Regexp
+    return old_square_brancket(*args) unless OnigRegexp.regexp_arg?(args[0])
 
     if args.size == 2
       match = args[0].match(self)
@@ -107,7 +123,7 @@ class String
   alias_method :slice, :[]
 
   def []=(*args)
-    return old_square_brancket_equal(*args) unless args[0].class == Regexp
+    return old_square_brancket_equal(*args) unless OnigRegexp.regexp_arg?(args[0])
 
     n_args = args.size
     case n_args
@@ -132,10 +148,8 @@ class String
       result = slice(*args)
       nth = args[0]
 
-      if nth.class == Regexp
-        lm = Regexp.last_match
-        self[nth] = '' if result
-        Regexp.last_match = lm
+      if OnigRegexp.regexp_arg?(nth)
+        OnigRegexp.preserving_last_match { self[nth] = '' if result }
       else
         self[nth] = '' if result
       end
@@ -145,10 +159,8 @@ class String
       nth = args[0]
       len = args[1]
 
-      if nth.class == Regexp
-        lm = Regexp.last_match
-        self[nth, len] = '' if result
-        Regexp.last_match = lm
+      if OnigRegexp.regexp_arg?(nth)
+        OnigRegexp.preserving_last_match { self[nth, len] = '' if result }
       else
         self[nth, len] = '' if result && nth != self.size
       end
@@ -160,7 +172,7 @@ class String
   alias_method :old_index, :index
 
   def index(pattern, pos=0)
-    if pattern.class == Regexp
+    if OnigRegexp.regexp_arg?(pattern)
       str = self[pos..-1]
       if str
         if num = (pattern =~ str)

--- a/src/mruby_onig_regexp.c
+++ b/src/mruby_onig_regexp.c
@@ -1322,7 +1322,7 @@ mrb_mruby_onig_regexp_gem_init(mrb_state* mrb) {
 
   mrb_define_method(mrb, mrb->string_class, "onig_regexp_gsub", &string_gsub, MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1) | MRB_ARGS_BLOCK());
   mrb_define_method(mrb, mrb->string_class, "onig_regexp_sub", &string_sub, MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1) | MRB_ARGS_BLOCK());
-  mrb_define_method(mrb, mrb->string_class, "onig_regexp_split", &string_split, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, mrb->string_class, "onig_regexp_split", &string_split, MRB_ARGS_OPT(2));
   mrb_define_method(mrb, mrb->string_class, "onig_regexp_scan", &string_scan, MRB_ARGS_REQ(1) | MRB_ARGS_BLOCK());
   mrb_define_method(mrb, mrb->string_class, "onig_regexp_match?", &string_match_p, MRB_ARGS_REQ(1) | MRB_ARGS_OPT(1));
 }

--- a/test/mruby_onig_regexp.rb
+++ b/test/mruby_onig_regexp.rb
@@ -623,3 +623,28 @@ assert('OnigRegexp not default') do
 end
 
 Regexp = prev_regexp
+
+# When another implementation owns the Regexp constant (e.g. mruby core
+# mruby-regexp), an OnigRegexp argument must still be accepted by these
+# methods instead of falling through to the non-regexp code path. Use a
+# distinct narrow class to stand in for the foreign Regexp.
+foreign_regexp = Class.new
+prev_regexp = Regexp
+Regexp = foreign_regexp
+
+assert('String regexp methods accept OnigRegexp when Regexp is foreign') do
+  assert_not_equal OnigRegexp, Regexp
+
+  assert_equal 'o ', 'hello world'[OnigRegexp.new('o.')]
+  assert_equal 6, 'hello world'.index(OnigRegexp.new('world'))
+
+  string = 'abc'
+  string[OnigRegexp.new('.')] = 'A'
+  assert_equal 'Abc', string
+
+  string = 'hello'
+  assert_equal 'el', string.slice!(OnigRegexp.new('el'))
+  assert_equal 'hlo', string
+end
+
+Regexp = prev_regexp


### PR DESCRIPTION
Two mruby 4.0 compatibility fixes surfaced after adding mruby 4.0 / master to CI (#126).

1. Regexp argument detection in String#[], #[]=, #slice!, #index. These gated the regexp path on `arg.class == Regexp`. When another Regexp implementation (e.g. mruby core mruby-regexp) owns the `Regexp` constant, that check is false for an actual `OnigRegexp` instance, so the methods fell through to the non-regexp path and raised (e.g. `OnigRegexp cannot be converted to Integer`); `slice!` additionally called `Regexp.last_match=`, which the foreign class may not define. Detection is centralized in `OnigRegexp.regexp_arg?` (accepts both OnigRegexp and the core Regexp), and `slice!` now preserves last_match through `OnigRegexp.preserving_last_match`, using OnigRegexp's own last_match.

2. onig_regexp_split arity. It was registered as `MRB_ARGS_REQ(1)` while its body accepts 0..2 arguments (`mrb_get_args(..., "|oi", ...)`). mruby 4.0 enforces the declared arity, so a no-argument `split` (the `$;` path) raised `ArgumentError: wrong number of arguments (given 0, expected 1)`. Changed to `MRB_ARGS_OPT(2)` to match the implementation.

A regression test exercises [], []=, slice!, index with an OnigRegexp argument while the Regexp constant points at a different class. Verified green (KO: 0) on both a build where Regexp != OnigRegexp and an onig-only build.