### PR TITLE
Add default gembox to CI build config

### DIFF
--- a/.github/workflows/config.rb
+++ b/.github/workflows/config.rb
@@ -1,6 +1,7 @@
 MRuby::Build.new do |conf|
   toolchain :gcc
   enable_debug
+  conf.gembox 'default'
   enable_test
 
   gem "#{MRUBY_ROOT}/.."
@@ -9,6 +10,7 @@ end
 MRuby::Build.new("onigmo-bundled") do |conf|
   toolchain :gcc
   enable_debug
+  conf.gembox 'default'
   enable_test
 
   gem "#{MRUBY_ROOT}/.." do |g|


### PR DESCRIPTION
The mruby-test harness now enables Prism compiler mode unless `mruby-compiler-lrama` is present, which makes `driver.c` reference `global_mrb`. With the minimal CI config no compiler gem is linked into libmruby, so the symbol is undefined and the link fails on mruby-master.

Adding `conf.gembox 'default'` pulls in a compiler gem and resolves the symbol.